### PR TITLE
LanguageDetector sets now also the application locale

### DIFF
--- a/src/LanguageDetector.php
+++ b/src/LanguageDetector.php
@@ -2,7 +2,7 @@
 
 namespace Vluzrmos\LanguageDetector;
 
-use Symfony\Component\Translation\TranslatorInterface as Translator;
+use Illuminate\Foundation\Application;
 use Vluzrmos\LanguageDetector\Contracts\DetectorDriverInterface as Driver;
 use Vluzrmos\LanguageDetector\Contracts\LanguageDetectorInterface;
 use Vluzrmos\LanguageDetector\Contracts\ShouldPrefixRoutesInterface as ShouldPrefixRoute;
@@ -13,10 +13,10 @@ use Vluzrmos\LanguageDetector\Contracts\ShouldPrefixRoutesInterface as ShouldPre
 class LanguageDetector implements LanguageDetectorInterface
 {
     /**
-     * Translator instance.
-     * @var Translator
+     * Application.
+     * @var Application
      */
-    protected $translator;
+    protected $app;
 
     /**
      * Driver to detect and apply the language.
@@ -25,12 +25,11 @@ class LanguageDetector implements LanguageDetectorInterface
     protected $driver;
 
     /**
-     * @param Translator $translator
-     * @param Driver     $driver
+     * @param Driver $driver
      */
-    public function __construct(Translator $translator, Driver $driver = null)
+    public function __construct(Driver $driver = null)
     {
-        $this->translator = $translator;
+        $this->app = app();
         $this->driver = $driver;
     }
 
@@ -87,7 +86,7 @@ class LanguageDetector implements LanguageDetectorInterface
      */
     public function apply($locale)
     {
-        $this->translator->setLocale($locale);
+        $this->app->setLocale($locale);
     }
 
     /**
@@ -100,7 +99,7 @@ class LanguageDetector implements LanguageDetectorInterface
         $driver = $this->getDriver();
 
         if ($driver instanceof ShouldPrefixRoute) {
-            return $driver->routePrefix($this->translator->getLocale());
+            return $driver->routePrefix($this->app->getLocale());
         }
 
         return '';

--- a/src/Providers/LanguageDetectorServiceProvider.php
+++ b/src/Providers/LanguageDetectorServiceProvider.php
@@ -5,7 +5,6 @@ namespace Vluzrmos\LanguageDetector\Providers;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Http\Request;
 use Illuminate\Support\ServiceProvider;
-use Symfony\Component\Translation\TranslatorInterface as Translator;
 use Vluzrmos\LanguageDetector\Drivers\AbstractDetector;
 use Vluzrmos\LanguageDetector\LanguageDetector;
 
@@ -14,12 +13,6 @@ use Vluzrmos\LanguageDetector\LanguageDetector;
  */
 class LanguageDetectorServiceProvider extends ServiceProvider
 {
-    /**
-     * Symfony translator.
-     * @var Translator
-     */
-    protected $translator;
-
     /**
      * Illuminate Request.
      * @var Request
@@ -49,7 +42,6 @@ class LanguageDetectorServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->translator = $this->app['translator'];
         $this->config = $this->app['config'];
         $this->request = $this->app['request'];
 
@@ -151,7 +143,6 @@ class LanguageDetectorServiceProvider extends ServiceProvider
             $contract,
             function () use ($driver) {
                 return new LanguageDetector(
-                    $this->translator,
                     $this->app['language.driver.'.$driver]
                 );
             }

--- a/tests/Drivers/AbstractDriversTestCase.php
+++ b/tests/Drivers/AbstractDriversTestCase.php
@@ -33,9 +33,9 @@ abstract class AbstractDriversTestCase extends TestCase
 
         $this->translator = $this->app['translator'];
 
-        $this->detector = new LanguageDetector($this->translator);
+        $this->detector = new LanguageDetector();
 
-        $this->translator->setLocale('fr');
+        $this->app->setLocale('fr');
     }
 
     /**

--- a/tests/Providers/LanguageDetectorServiceProviderTest.php
+++ b/tests/Providers/LanguageDetectorServiceProviderTest.php
@@ -34,10 +34,11 @@ class LanguageDetectorServiceProviderTest extends TestCase
             $this->app['Vluzrmos\LanguageDetector\Contracts\LanguageDetectorInterface']
         );
 
-        $this->app['translator']->setLocale('fr');
+        $this->app->setLocale('fr');
 
         $this->app['language.detector']->detectAndApply();
 
+        $this->assertEquals('en', $this->app->getLocale());
         $this->assertEquals('en', $this->app['translator']->getLocale());
     }
 


### PR DESCRIPTION
Today I added your package to a little project (L 5.1 LTS). After I added and configured it, I saw at first no changes with an static page (without translations) and the laravel debugbar. The debugbar showed "en" instead of my locale "de". So I was a little bit confused.

After I added an translation to the view, the view was translated as expected, but the debugbar again showed "en" instead of "de".

After I looked in the sourcecode, I found out that this package only changes the locale on the translator and not directly on the application. 

So I changed the sourcecode that the package sets the new locale on application level (`App::setLocale(x)`) which also sets the locale on the translator. So everything works now as expected.

I would be thankful if you merge the PR as soon as possible so that I can use it on an other project as well :)

Thank you for the great package!
