### PR TITLE
Don’t re-save cookie if the language was already detected by cookie

### DIFF
--- a/src/LanguageDetector.php
+++ b/src/LanguageDetector.php
@@ -147,7 +147,9 @@ class LanguageDetector implements LanguageDetectorInterface
     {
         $this->translator->setLocale($locale);
 
-        $this->addCookieToQueue($locale);
+        if (!$this->getLanguageFromCookie()) {
+            $this->addCookieToQueue($locale);
+        }
 
         $this->applyCallbacks($locale);
     }


### PR DESCRIPTION
I was having an issue when setting manually the locale cookie, the lib would overwrite each time the cookie for each request.