### PR TITLE
Add Laravel package discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,13 @@
       "Vluzrmos\\LanguageDetector\\Testing\\": "tests/"
     }
   },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Vluzrmos\\LanguageDetector\\Providers\\LanguageDetectorServiceProvider,"
+      ]
+    }
+  },
   "config": {
     "preferred-install": "dist"
   },


### PR DESCRIPTION
Use of [package discovery](https://laravel.com/docs/8.x/packages#package-discovery) so adding it in `config/app.php` is not necessary anymore